### PR TITLE
Closes #2 - Fix the generated projects by removing template from naming

### DIFF
--- a/src/content/api/src/Template.WebApi/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/content/api/src/Template.WebApi/Extensions/ApplicationBuilderExtensions.cs
@@ -15,7 +15,7 @@ namespace Template.WebApi.Extensions
 
             app.Run(async context =>
             {
-                var content = LoadTemplateFromEmbeddedResource(applicationName);
+                var content = LoadStartPageFromEmbeddedResource(applicationName);
                 if (string.IsNullOrEmpty(content))
                     content = applicationName;
 
@@ -24,10 +24,10 @@ namespace Template.WebApi.Extensions
             });
         }
 
-        private static string LoadTemplateFromEmbeddedResource(string applicationName)
+        private static string LoadStartPageFromEmbeddedResource(string applicationName)
         {
             var assembly = typeof(Startup).Assembly;
-            var resourceName = assembly.GetManifestResourceNames().First(s => s.EndsWith("home.html",StringComparison.CurrentCultureIgnoreCase));
+            var resourceName = assembly.GetManifestResourceNames().First(s => s.EndsWith("home.html", StringComparison.CurrentCultureIgnoreCase));
             if (string.IsNullOrEmpty(resourceName))
                 return null;
 


### PR DESCRIPTION
Having a Template in naming caused the templating engine to replace that in the code wrongly. The current change fixes the generation. 

Fixes

- Bug #2 

## Type of change

- [*] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

It's been tested by generating a sample API and compiling and testing 

## Checklist:

- [*] My code follows the style guidelines of this project
- [*] I have performed a self-review of my own code